### PR TITLE
Support SEMI-EPG

### DIFF
--- a/rail-vars.el
+++ b/rail-vars.el
@@ -42,6 +42,7 @@
 ;; replace candidates for replacement
 (defvar rail-product-name-alist
   '(("SEMI"          . semi)
+    ("SEMI-EPG"      . semi)
     ("WEMI"          . semi)
     ("REMI"          . semi)
     ("WREMI"         . semi)


### PR DESCRIPTION
In Debian unstable, SEMI-EPG patch is applied to the semi package
version 1.14.7~0.20120428-2.  Please support it.
